### PR TITLE
Verbesserung Matching Legendeneintrag und Darstellungsdienst aus externem Katalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate
 ```
 
 Be aware, that the packed test data might come out of sync to ÖREBlex. In this case download a newer Version
@@ -80,8 +80,8 @@ docker run \
     -e TARGET_BASKET_ID="ch.BelasteteStandorte" \
     -e XTF_FILE="ch.BelasteteStandorte.sh.mgdm.v1_5.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
-
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
+```
 ## Planungszonen
 
 ### v1.1 ÖREBlex
@@ -103,7 +103,7 @@ docker run \
     -e OEREBLEX_CANTON="gr" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate
 ```
 **special test with empty zones (it should not output any legendentries nor view services**
 
@@ -122,7 +122,7 @@ docker run \
     -e OEREBLEX_CANTON="gr" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate
 ```
 
 #### SH
@@ -142,7 +142,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate
 ```
 
 Frische Daten können hier heruntergeladen werden:
@@ -163,7 +163,7 @@ docker run \
     -e TARGET_BASKET_ID="ch.Planungszonen" \
     -e XTF_FILE="ch.Planungszonen.sh.mgdm.v1_1.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
 ```
 
 ## Nutzungsplanung
@@ -187,7 +187,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex 
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate 
 ```
 
 ### v1.2
@@ -205,7 +205,7 @@ docker run \
     -e TARGET_BASKET_ID="ch.tha.Nutzungsplanung" \
     -e XTF_FILE="ch.Nutzungsplanung.sh.tha.mgdm.v1_2.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
 ```
 
 ## Statische Waldgrenzen
@@ -229,7 +229,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex 
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate 
 ```
 
 ### v1.2
@@ -247,7 +247,7 @@ docker run \
     -e TARGET_BASKET_ID="ch.StatischeWaldgrenzen" \
     -e XTF_FILE="ch.Waldgrenzen.sh.mgdm.v1_2.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
 ```
 
 ## Lärmempfindlichkeitsstufen
@@ -271,7 +271,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex 
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate 
 ```
 
 ### v1.2
@@ -289,7 +289,7 @@ docker run \
     -e TARGET_BASKET_ID="ch.tha.Laermempfindlichkeitsstufen" \
     -e XTF_FILE="ch.Laermempfindlichkeitsstufen.sh.tha.mgdm.v1_2.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
 ```
 
 ## Planerischer Gewässerschutz - Grundwasserschutzzonen
@@ -313,7 +313,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex 
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate 
 ```
 
 ### v1.2
@@ -331,7 +331,7 @@ docker run \
     -e TARGET_BASKET_ID="ch.Grundwasserschutzzonen" \
     -e XTF_FILE="ch.Planerischergewaesserschutz.sh.mgdm.v1_2.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
 ```
 
 ## Planerischer Gewässerschutz - Grundwasserschutzareale
@@ -355,7 +355,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex 
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate 
 ```
 
 ### v1.2
@@ -373,7 +373,7 @@ docker run \
     -e TARGET_BASKET_ID="ch.Grundwasserschutzareale" \
     -e XTF_FILE="ch.Planerischergewaesserschutz.sh.mgdm.v1_2.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
 ```
 
 ## Waldreservate
@@ -393,7 +393,7 @@ docker run \
     -e TARGET_BASKET_ID="ch.Waldreservate" \
     -e XTF_FILE="ch.Waldreservate.sh.mgdm.v1_2.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
 ```
 
 ### v1.2 ÖREBlex
@@ -415,7 +415,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate
 ```
 
 ## Gewässerraum
@@ -424,6 +424,8 @@ docker run \
 
 #### SH
 
+
+Aktuell funktioniert aktuell nicht, da die ÖREBlexdaten kaputt sind.
 ```bash
 docker run \
     --rm \
@@ -439,7 +441,7 @@ docker run \
     -e OEREBLEX_CANTON="sh" \
     -e DUMMY_OFFICE_NAME="DUMMYOFFICE" \
     -e DUMMY_OFFICE_URL="https://google.ch" \
-    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex
+    mgdm2oereb-transformator:latest make clean clean_oereblex_xml mgdm2oereb-oereblex validate
 ```
 
 ### v1.1
@@ -457,5 +459,5 @@ docker run \
     -e TARGET_BASKET_ID="ch.Gewaesserraum" \
     -e XTF_FILE="ch.Gewaesserraum.sh.mgdm.v1_1.xtf" \
     -e CATALOG="ch.sh.OeREBKRMkvs_supplement.xml" \
-    mgdm2oereb-transformator:latest make clean mgdm2oereb
+    mgdm2oereb-transformator:latest make clean mgdm2oereb validate
 ```

--- a/xsl/Gewaesserraum_V1_1.oereblex.trafo.xsl
+++ b/xsl/Gewaesserraum_V1_1.oereblex.trafo.xsl
@@ -111,8 +111,12 @@
         <!--<xsl:comment><xsl:value-of select="$typ_art_code"/></xsl:comment>-->
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_art_code]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_art_code]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">

--- a/xsl/Gewaesserraum_V1_1.trafo.xsl
+++ b/xsl/Gewaesserraum_V1_1.trafo.xsl
@@ -126,8 +126,12 @@
         <!--<xsl:comment><xsl:value-of select="$typ_art_code"/></xsl:comment>-->
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_art_code]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_art_code]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="ili:Gewaesserraum_V1_1.GewR.MultilingualUri/ili:LocalisedText/ili:Gewaesserraum_V1_1.GewR.LocalisedUri">

--- a/xsl/Laermempfindlichkeitsstufen_V1_2.oereblex.trafo.xsl
+++ b/xsl/Laermempfindlichkeitsstufen_V1_2.oereblex.trafo.xsl
@@ -127,8 +127,12 @@
         </xsl:comment>
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">

--- a/xsl/Laermempfindlichkeitsstufen_V1_2.trafo.xsl
+++ b/xsl/Laermempfindlichkeitsstufen_V1_2.trafo.xsl
@@ -121,8 +121,12 @@
         </xsl:comment>-->
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">

--- a/xsl/Nutzungsplanung_V1_2.oereblex.trafo.xsl
+++ b/xsl/Nutzungsplanung_V1_2.oereblex.trafo.xsl
@@ -150,8 +150,12 @@
 
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=concat($typ_art_code, '_', $rechtsstatus)]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=concat($typ_art_code, '_', $rechtsstatus)]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="ili:Nutzungsplanung_V1_2.MultilingualUri/ili:LocalisedText/ili:Nutzungsplanung_V1_2.LocalisedUri">

--- a/xsl/Nutzungsplanung_V1_2.trafo.xsl
+++ b/xsl/Nutzungsplanung_V1_2.trafo.xsl
@@ -146,8 +146,12 @@
 
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=concat($typ_art_code, '_', $rechtsstatus)]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=concat($typ_art_code, '_', $rechtsstatus)]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="ili:Nutzungsplanung_V1_2.MultilingualUri/ili:LocalisedText/ili:Nutzungsplanung_V1_2.LocalisedUri">

--- a/xsl/PlanerischerGewaesserschutz_V1_2.oereblex.trafo.xsl
+++ b/xsl/PlanerischerGewaesserschutz_V1_2.oereblex.trafo.xsl
@@ -214,8 +214,12 @@
         </xsl:comment>-->
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">

--- a/xsl/PlanerischerGewaesserschutz_V1_2.trafo.xsl
+++ b/xsl/PlanerischerGewaesserschutz_V1_2.trafo.xsl
@@ -210,8 +210,12 @@
         </xsl:comment>-->
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">

--- a/xsl/Planungszonen_V1_1.oereblex.trafo.xsl
+++ b/xsl/Planungszonen_V1_1.oereblex.trafo.xsl
@@ -110,8 +110,12 @@
         <xsl:variable name="typ_code" select="../ili:Planungszonen_V1_1.Geobasisdaten.Typ_Planungszone[@TID=$typ_ref_id]/ili:Festlegung_Stufe"/>
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=concat($typ_code,'_',$rechtsstatus)]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=concat($typ_code,'_',$rechtsstatus)]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">

--- a/xsl/Planungszonen_V1_1.trafo.xsl
+++ b/xsl/Planungszonen_V1_1.trafo.xsl
@@ -109,8 +109,12 @@
         <xsl:variable name="typ_code" select="../ili:Planungszonen_V1_1.Geobasisdaten.Typ_Planungszone[@TID=$typ_ref_id]/ili:Festlegung_Stufe"/>
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=concat($typ_code,'_',$rechtsstatus)]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=concat($typ_code,'_',$rechtsstatus)]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="ili:Planungszonen_V1_1.MultilingualUri/ili:LocalisedText/ili:Planungszonen_V1_1.LocalisedUri">

--- a/xsl/SH_Waldreservate_V1_2.oereblex.trafo.xsl
+++ b/xsl/SH_Waldreservate_V1_2.oereblex.trafo.xsl
@@ -109,8 +109,12 @@
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/ili:DarstellungsDienst/@REF"/>
 
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">

--- a/xsl/SH_Waldreservate_V1_2.trafo.xsl
+++ b/xsl/SH_Waldreservate_V1_2.trafo.xsl
@@ -119,8 +119,12 @@
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/ili:DarstellungsDienst/@REF"/>
 
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template match="ili:SH_Waldreservate_V1_2.Waldreservate.MultilingualUri/ili:LocalisedText/ili:SH_Waldreservate_V1_2.Waldreservate.LocalisedUri">

--- a/xsl/Waldgrenzen_V1_2.oereblex.trafo.xsl
+++ b/xsl/Waldgrenzen_V1_2.oereblex.trafo.xsl
@@ -119,8 +119,12 @@
         </xsl:comment>
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">

--- a/xsl/Waldgrenzen_V1_2.trafo.xsl
+++ b/xsl/Waldgrenzen_V1_2.trafo.xsl
@@ -113,8 +113,12 @@
         </xsl:comment> -->
         <xsl:variable name="legende_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/@TID"/>
         <xsl:variable name="darstellungsdienst_tid" select="$catalog_doc//ili:TRANSFER/ili:DATASECTION/ili:OeREBKRMlegdrst_V2_0.Transferstruktur/ili:OeREBKRMlegdrst_V2_0.Transferstruktur.LegendeEintrag[ili:Thema=$theme_code][ili:ArtCode=$typ_artcode]/ili:DarstellungsDienst/@REF"/>
-        <Legende REF="{$legende_tid}"/>
-        <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        <xsl:if test="$legende_tid">
+            <Legende REF="{$legende_tid}"/>
+        </xsl:if>
+        <xsl:if test="$darstellungsdienst_tid">
+            <DarstellungsDienst REF="{$darstellungsdienst_tid}"/>
+        </xsl:if>
     </xsl:template>
 
     <xsl:template name="zustaendige_stelle">


### PR DESCRIPTION
Wenn kein passender Legendeneintrag und Darstellungsdienst im externen Katalog gefunden werden kann, werden nun keine leeren Referenzen mehr abgelegt, sondern garkeine. Damit sollten in diesem Fall invalide XTF's erzeugt werden und die Trafo kann fehlschlagen.